### PR TITLE
Remove `sassc` from gem runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,10 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-
+gem 'isodoc',
+    git: 'https://github.com/metanorma/isodoc.git',
+    branch: 'feature/sassc-gem-dependecey-removal',
+    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-gem 'isodoc',
-    git: 'https://github.com/metanorma/isodoc.git',
-    branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,23 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'isodoc/gem_tasks'
 
+module IsoDoc
+  module GemTasks
+    module_function
+
+    def fonts_placeholder
+      <<~TEXT
+        $bodyfont: '{{bodyfont}}';
+        $headerfont: '{{headerfont}}';
+        $monospacefont: '{{monospacefont}}';
+        $titlefont: '{{titlefont}}';
+      TEXT
+    end
+  end
+end
+
+IsoDoc::GemTasks.install
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/lib/isodoc/gb/base_convert.rb
+++ b/lib/isodoc/gb/base_convert.rb
@@ -7,14 +7,14 @@ require "fileutils"
 module IsoDoc
   module Gb
     module BaseConvert
-      def extract_fonts(options)
+      def scss_fontheader
         b = options[:bodyfont] || "Arial"
         h = options[:headerfont] || "Arial"
         m = options[:monospacefont] || "Courier"
         t = options[:titlefont] || "Arial"
         "$bodyfont: #{b};\n$headerfont: #{h};\n$monospacefont: #{m};\n"\
           "$titlefont: #{t};\n"
-      end   
+      end
 
       def metadata_init(lang, script, labels)
         unless ["en", "zh"].include? lang

--- a/lib/isodoc/gb/html_convert.rb
+++ b/lib/isodoc/gb/html_convert.rb
@@ -27,6 +27,16 @@ module IsoDoc
         }
       end
 
+      def fonts_options
+        default_font_options = default_fonts(options)
+        {
+          bodyfont: options[:bodyfont] || default_font_options[:bodyfont],
+          headerfont: options[:headerfont] || default_font_options[:headerfont],
+          monospacefont: options[:monospacefont] || default_font_options[:monospacefont],
+          titlefont: options[:titlefont] || default_font_options[:titlefont]
+        }
+      end
+
       def default_file_locations(options)
         {
           htmlstylesheet: options[:compliant] ? html_doc_path("htmlcompliantstyle.scss") : html_doc_path("htmlstyle.scss"),
@@ -37,7 +47,7 @@ module IsoDoc
       end
 
       def populate_template(docxml, format)
-        meta = @meta.get.merge(@labels)
+        meta = @meta.get.merge(@labels).merge(@meta.fonts_options || {})
         logo = @common.format_logo(meta[:gbprefix], meta[:gbscope], format, @localdir)
         logofile = @meta.standard_logo(meta[:gbprefix])
         meta[:standard_agency_formatted] =

--- a/lib/isodoc/gb/word_convert.rb
+++ b/lib/isodoc/gb/word_convert.rb
@@ -24,11 +24,21 @@ module IsoDoc
           monospacefont: '"Courier New",monospace',
           titlefont: (scope == "national" ? (script != "Hans" ? '"Cambria",serif' : '"SimSun",serif' ) :
                       (script == "Hans" ? '"SimHei",sans-serif' : '"Calibri",sans-serif' ))
-        }     
-      end     
+        }
+      end
+
+      def fonts_options
+        default_font_options = default_fonts(options)
+        {
+          bodyfont: options[:bodyfont] || default_font_options[:bodyfont],
+          headerfont: options[:headerfont] || default_font_options[:headerfont],
+          monospacefont: options[:monospacefont] || default_font_options[:monospacefont],
+          titlefont: options[:titlefont] || default_font_options[:titlefont]
+        }
+      end
 
       def default_file_locations(options)
-        {   
+        {
           wordstylesheet: html_doc_path("wordstyle.scss"),
           standardstylesheet: html_doc_path("gb.scss"),
           header: html_doc_path("header.html"),
@@ -37,10 +47,10 @@ module IsoDoc
           ulstyle: "l7",
           olstyle: "l10",
         }
-      end 
+      end
 
       ENDLINE = <<~END.freeze
-      <v:line 
+      <v:line
  alt="" style='position:absolute;left:0;text-align:left;z-index:251662848;
  mso-wrap-edited:f;mso-width-percent:0;mso-height-percent:0;
  mso-width-percent:0;mso-height-percent:0'
@@ -71,7 +81,7 @@ module IsoDoc
       end
 
       def populate_template(docxml, format)
-        meta = @meta.get.merge(@labels)
+        meta = @meta.get.merge(@labels).merge(@meta.fonts_options || {})
         logo = @common.format_logo(meta[:gbprefix], meta[:gbscope], format, @localdir)
         logofile = @meta.standard_logo(meta[:gbprefix])
         meta[:standard_agency_formatted] =

--- a/metanorma-gb.gemspec
+++ b/metanorma-gb.gemspec
@@ -30,12 +30,13 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "metanorma-iso", "~> 1.4.0"
-  spec.add_dependency "isodoc", "~> 1.1.0"
+  # spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "twitter_cldr", "~> 4.4.4"
   spec.add_dependency "gb-agencies", "~> 0.0.4"
   spec.add_dependency "htmlentities", "~> 4.3.4"
 
   spec.add_development_dependency "byebug", "~> 9.1"
+  spec.add_development_dependency "sassc", "2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"

--- a/metanorma-gb.gemspec
+++ b/metanorma-gb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "metanorma-iso", "~> 1.4.0"
-  # spec.add_dependency "isodoc", "~> 1.1.0"
+  spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "twitter_cldr", "~> 4.4.4"
   spec.add_dependency "gb-agencies", "~> 0.0.4"
   spec.add_dependency "htmlentities", "~> 4.3.4"


### PR DESCRIPTION
metanorma/metanorma#109 moved sassc gem to dev dependency, temporarily added isodoc to Gemfile, added rake build script override.